### PR TITLE
Feature: conditionally send notifications to stakeholders in producti…

### DIFF
--- a/app/Http/Controllers/PreInscriptionController.php
+++ b/app/Http/Controllers/PreInscriptionController.php
@@ -172,7 +172,10 @@ class PreInscriptionController extends Controller
                 ]);
             }
 
-            $this->sendNotificationToResponsible($preInscription);
+            # if APP_ENV is production, send notification to the stake responsible
+            if (config('app.env') === 'production') {
+                $this->sendNotificationToResponsible($preInscription);
+            }
 
             return back()->with('success', $filterResult['message']);
         } catch (Exception $e) {
@@ -500,9 +503,9 @@ class PreInscriptionController extends Controller
             foreach ($preInscriptions as $preInscription) {
                 // Columna B: Nombre completo (Candidato)
                 $fullName = trim($preInscription->first_name . ' ' .
-                           ($preInscription->middle_name ? $preInscription->middle_name . ' ' : '') .
-                           $preInscription->last_name . ' ' .
-                           ($preInscription->second_last_name ? $preInscription->second_last_name : ''));
+                    ($preInscription->middle_name ? $preInscription->middle_name . ' ' : '') .
+                    $preInscription->last_name . ' ' .
+                    ($preInscription->second_last_name ? $preInscription->second_last_name : ''));
                 $worksheet->setCellValue('B' . $row, $fullName);
 
                 // Columna C: Género
@@ -555,7 +558,6 @@ class PreInscriptionController extends Controller
             $writer->save($tempPath);
 
             return response()->download($tempPath, $filename)->deleteFileAfterSend(true);
-
         } catch (\Exception $e) {
             return back()->withErrors(['error' => 'Error al generar el archivo Excel: ' . $e->getMessage()]);
         }

--- a/app/Http/Controllers/ReferenceController.php
+++ b/app/Http/Controllers/ReferenceController.php
@@ -155,7 +155,10 @@ class ReferenceController extends Controller
 
             $stake = Stake::find($validated['stake_id']);
             $user = $stake->user;
-            $user->notify(new RequestNotification($this->buildReferenceNotification($user, $reference)));
+            # if APP_ENV is production, send notification to the stake responsible
+            if (config('app.env') === 'production') {
+                $user->notify(new RequestNotification($this->buildReferenceNotification($user, $reference)));
+            }
 
             return  back()->with('success', $message);
         } catch (\Illuminate\Validation\ValidationException $e) {
@@ -525,7 +528,6 @@ class ReferenceController extends Controller
             $writer->save($tempPath);
 
             return response()->download($tempPath, $filename)->deleteFileAfterSend(true);
-
         } catch (\Exception $e) {
             return back()->withErrors(['error' => 'Error al generar el archivo Excel: ' . $e->getMessage()]);
         }


### PR DESCRIPTION
This pull request introduces an environment check to ensure that notification emails are only sent in production, and makes minor cleanup improvements to the Excel export methods in both the `PreInscriptionController` and `ReferenceController`.

Notification logic changes:

* In both `PreInscriptionController@store` and `ReferenceController@store`, notification emails to the stake responsible are now only sent if the application environment is set to production, preventing notifications from being sent in non-production environments. [[1]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254R175-R178) [[2]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eR158-R161)

Code cleanup:

* Removed unnecessary blank lines after the file download response in the `exportPendingToExcel` methods of both controllers for minor code consistency. [[1]](diffhunk://#diff-cc8cf07424ba2e1ae3256739dc1683155616cd19ca0ca990ffc74b3bfaa90254L558) [[2]](diffhunk://#diff-d669d1e952a4f19eb9fd7b69ae5bfbd3f4b07289c07a8802d936f9833495ab4eL528)